### PR TITLE
Drop blueprint-compiler

### DIFF
--- a/nl.emphisia.icon.json
+++ b/nl.emphisia.icon.json
@@ -32,20 +32,6 @@
     ],
     "modules": [
         {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": [
-                "*"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.18.0"
-                }
-            ]
-        },
-        {
             "name" : "Iconic",
             "buildsystem" : "meson",
             "sources" : [


### PR DESCRIPTION
Blueprint compiler is now part of GNOME runtime 49.